### PR TITLE
Update sign up guidance for NHS Wales-only access, add service metrics charts and navigation

### DIFF
--- a/guides.html
+++ b/guides.html
@@ -45,6 +45,7 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="solutions.html">Solutions Exchange</a></li>
+                    <li class="nav-item"><a class="nav-link" href="service-metrics.html">Service Metrics</a></li>
                     <li class="nav-item"><a class="nav-link active" href="guides.html">Guides</a></li>
                     <li class="nav-item"><a class="nav-link btn btn-primary text-white ms-2 px-3" href="signup.html">Sign Up</a></li>
                 </ul>
@@ -63,7 +64,7 @@
                     <p class="lead">Comprehensive guides to help you navigate, contribute to, and make the most of the NHS Wales Solutions Exchange.</p>
                 </div>
                 <div class="col-lg-4 text-end">
-                    <img src="assets/img/information.jpg" alt="Information and Guidance" class="img-fluid rounded shadow" style="max-height: 200px; object-fit: cover;">
+                    <i class="fas fa-handshake text-primary" style="font-size: 4rem; opacity: 0.3;"></i>
                 </div>
             </div>
         </div>
@@ -71,11 +72,51 @@
 
     <!-- Guides Section -->
     <section id="guides" class="py-5">
-        <div class="container">
+    <div class="container">
             <div class="row">
                 <div class="col-lg-10 mx-auto">
                     <div class="accordion" id="guidesAccordion">
                         
+                        <!-- GitHub GIG Cymru Service Overview & FAQ -->
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="gigCymruOverviewHeading">
+                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#gigCymruOverview" aria-expanded="true" aria-controls="gigCymruOverview">
+                                    <i class="fas fa-info-circle me-2"></i>GitHub GIG Cymru: Service Overview & FAQ
+                                </button>
+                            </h2>
+                            <div id="gigCymruOverview" class="accordion-collapse collapse show" aria-labelledby="gigCymruOverviewHeading" data-bs-parent="#guidesAccordion">
+                                <div class="accordion-body">
+                                    <h5>About GitHub GIG Cymru</h5>
+                                    <p>GitHub GIG Cymru is a managed, version-controlled code collaboration platform for NHS Wales, supporting open-source and reusable code, and enabling cross-organizational collaboration for analytics and development projects.</p>
+                                    <div class="alert alert-warning mt-3 mb-3">
+                                        <strong>Access Notice:</strong> Only users who are part of NHS Wales can have access to internal repositories and be members of GitHub GIG Cymru. Access is not available to external users.
+                                    </div>
+                                    <h5>Frequently Asked Questions</h5>
+                                    <ul>
+                                        <li><strong>Who can use it?</strong> Only users who are part of NHS Wales organizations can access internal repositories and join GitHub GIG Cymru.</li>
+                                        <li><strong>How do I get access?</strong> Raise a ticket with your local IT help desk. Your request will be escalated to the national IT service desk for triage and access setup.</li>
+                                        <li><strong>How do I get Codespaces or Co-Pilot?</strong> These require additional funding. Contact the service for a cost estimate and access process.</li>
+                                        <li><strong>What training is available?</strong> Access <a href="https://github.com/GIGCymru/Guides" target="_blank">GitHub Help Documentation</a>, the <a href="https://github.com/GIGCymru/" target="_blank">GIG Cymru Documentation</a>, and community forums.</li>
+                                        <li><strong>How do I share code?</strong> Create a repository in your organization’s GitHub space, set it to Internal, or invite collaborators directly.</li>
+                                        <li><strong>How do I follow best practice?</strong> Use code reviews, pull requests, and follow your organization’s coding standards. Document shared standards in your repos.</li>
+                                        <li><strong>Where do I go for help?</strong> Use the <a href="https://docs.github.com/en/get-started" target="_blank">GitHub Help Docs</a>, contact the Advanced Analytics Team, or join community forums.</li>
+                                        <li><strong>How do I suggest improvements?</strong> Raise issues in relevant repos, join forums, or contact the NDR Advanced Analytics Team.</li>
+                                        <li><strong>What features are included?</strong> Private repos, team management, code review, project management, GitHub Actions, security, analytics, Co-Pilot, and Codespaces (some features may require extra cost).</li>
+                                        <li><strong>How is security managed?</strong> GitHub Enterprise provides encryption, access controls, and monitoring. All users are synced with NHS Wales Active Directory. Follow NHS Wales data protection policies.</li>
+                                        <li><strong>What are DHCW roles?</strong> The DHCW NDR Advanced Analytics Team manages the service, users, organizations, and provides support and guidance.</li>
+                                        <li><strong>Strategic goals supported:</strong> Digital transformation, high-quality digital services, cross-organizational collaboration, innovation, and trusted IT service management.</li>
+                                        <li><strong>What projects are supported?</strong> Cross-organization, open source, big data, research, proof of concept, hackathons, and infrastructure projects.</li>
+                                    </ul>
+                                    <h5>Resources & Support</h5>
+                                    <ul>
+                                        <li><a href="https://github.com/GIGCymru/GitHub-GIG-Cymru/wiki" target="_blank">GIG Cymru Wiki</a></li>
+                                        <li><a href="https://github.com/GIGCymru/Guides" target="_blank">Guides & Documentation</a></li>
+                                        <li><a href="https://github.com/GIGCymru/GitHub-GIG-Cymru-FAQ" target="_blank">FAQ Repository</a></li>
+                                    </ul>
+                                    <p class="mb-0"><strong>Contact:</strong> For support, contact your local IT desk or the NDR Advanced Analytics Team.</p>
+                                </div>
+                            </div>
+                        </div>
                         <!-- Getting Started Guide -->
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="gettingStartedHeading">
@@ -466,20 +507,15 @@
                 <div class="col-lg-12 mb-12 p-2 flex-fill footer-logo">
                     <img class="nav-large-image" src="assets/img/nhswales_logo_black and white.jpg" alt="NHS Wales | GIG CYMRU Logo">
                 </div>
-                
                 <section class="p-2 flex-fill footer-section">
                     <ul class="justify-content-center">
                         <li><a href="https://dhcw.nhs.wales//use-of-site/accessibility/" class="nav-link" target="_self">Accessibility statement</a></li>
-							
-								<li><a href="https://dhcw.nhs.wales//use-of-site/terms-of-use/" class="nav-link" target="_self">Terms of use</a></li>
-							
-								<li><a href="https://dhcw.nhs.wales//use-of-site/freedom-of-information/" class="nav-link" target="_self">Freedom of information</a></li>
-							
-								<li><a href="https://dhcw.nhs.wales//use-of-site/privacy-policy/" class="nav-link" target="_self">Privacy Policy</a></li>
+                        <li><a href="https://dhcw.nhs.wales//use-of-site/terms-of-use/" class="nav-link" target="_self">Terms of use</a></li>
+                        <li><a href="https://dhcw.nhs.wales//use-of-site/freedom-of-information/" class="nav-link" target="_self">Freedom of information</a></li>
+                        <li><a href="https://dhcw.nhs.wales//use-of-site/privacy-policy/" class="nav-link" target="_self">Privacy Policy</a></li>
                     </ul>
                 </section>
             </div>
-
             <div class="builtBy">
                 Built by <a href="https://dhcw.nhs.wales/our-programmes/national-data-resource1/" target="_self">NDR - National Data Resource</a>
             </div>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link active" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="solutions.html">Solutions Exchange</a></li>
+                    <li class="nav-item"><a class="nav-link" href="service-metrics.html">Service Metrics</a></li>
                     <li class="nav-item"><a class="nav-link" href="guides.html">Guides</a></li>
                     <li class="nav-item"><a class="nav-link btn btn-primary text-white ms-2 px-3" href="signup.html">Sign Up</a></li>
                     <li class="nav-item dropdown ms-2">

--- a/service-metrics.html
+++ b/service-metrics.html
@@ -48,7 +48,20 @@
             <canvas id="orgReposChart"></canvas>
         </div>
 
-        <!-- Add more charts as needed -->
+        <div class="chart-container">
+            <h4>Repositories by Programming Language</h4>
+            <canvas id="langDistChart"></canvas>
+        </div>
+
+        <div class="chart-container">
+            <h4>Repository Stars Distribution</h4>
+            <canvas id="starsDistChart"></canvas>
+        </div>
+
+        <div class="chart-container">
+            <h4>Recent Activity Trend (Commits)</h4>
+            <canvas id="activityTrendChart"></canvas>
+        </div>
     </div>
 
     <footer class="mt-5">
@@ -61,9 +74,12 @@
     <script>
     // Fetch data and render charts
     document.addEventListener('DOMContentLoaded', async function() {
-        const repoData = await fetch('data/repositories.json').then(r => r.json());
-        renderRepoGrowthChart(repoData);
-        renderOrgReposChart(repoData);
+    const repoData = await fetch('data/repositories.json').then(r => r.json());
+    renderRepoGrowthChart(repoData);
+    renderOrgReposChart(repoData);
+    renderLangDistChart(repoData);
+    renderStarsDistChart(repoData);
+    renderActivityTrendChart(repoData);
     });
 
     // Chart 1: Repository Growth Over Time
@@ -143,6 +159,105 @@
                 scales: {
                     x: { stacked: true, title: { display: true, text: 'Organisation' } },
                     y: { stacked: true, beginAtZero: true, title: { display: true, text: 'Repositories' } }
+                }
+            }
+        });
+    }
+
+    // Chart 3: Language Distribution
+    function renderLangDistChart(repos) {
+        const langCounts = {};
+        repos.forEach(repo => {
+            const lang = repo.language || 'Unknown';
+            langCounts[lang] = (langCounts[lang] || 0) + 1;
+        });
+        const labels = Object.keys(langCounts);
+        const data = labels.map(l => langCounts[l]);
+        new Chart(document.getElementById('langDistChart').getContext('2d'), {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Repositories',
+                    data: data,
+                    backgroundColor: [
+                        '#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#20c997', '#fd7e14', '#343a40', '#17a2b8', '#6610f2'
+                    ]
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: { legend: { position: 'bottom' } }
+            }
+        });
+    }
+
+    // Chart 4: Stars Distribution
+    function renderStarsDistChart(repos) {
+        // Group by star buckets
+        const buckets = { '0': 0, '1-4': 0, '5-9': 0, '10-24': 0, '25+': 0 };
+        repos.forEach(repo => {
+            const stars = repo.stargazers_count || 0;
+            if (stars === 0) buckets['0']++;
+            else if (stars < 5) buckets['1-4']++;
+            else if (stars < 10) buckets['5-9']++;
+            else if (stars < 25) buckets['10-24']++;
+            else buckets['25+']++;
+        });
+        const labels = Object.keys(buckets);
+        const data = labels.map(l => buckets[l]);
+        new Chart(document.getElementById('starsDistChart').getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Repositories',
+                    data: data,
+                    backgroundColor: '#6f42c1'
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: { legend: { display: false } },
+                scales: {
+                    x: { title: { display: true, text: 'Stars' } },
+                    y: { beginAtZero: true, title: { display: true, text: 'Repositories' } }
+                }
+            }
+        });
+    }
+
+    // Chart 5: Recent Activity Trend (Commits)
+    function renderActivityTrendChart(repos) {
+        // Simulate with pushed_at dates (as commit data is not available)
+        const activity = {};
+        repos.forEach(repo => {
+            const date = repo.pushed_at ? repo.pushed_at.slice(0, 10) : null;
+            if (date) {
+                activity[date] = (activity[date] || 0) + 1;
+            }
+        });
+        const dates = Object.keys(activity).sort();
+        const data = dates.map(date => ({ x: date, y: activity[date] }));
+        new Chart(document.getElementById('activityTrendChart').getContext('2d'), {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'Active Repositories (by last push)',
+                    data: data,
+                    borderColor: '#fd7e14',
+                    backgroundColor: 'rgba(253,126,20,0.1)',
+                    fill: true,
+                    tension: 0.2,
+                    pointRadius: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: { legend: { display: true } },
+                scales: {
+                    x: { type: 'time', time: { unit: 'month' }, title: { display: true, text: 'Date' } },
+                    y: { beginAtZero: true, title: { display: true, text: 'Active Repositories' } }
                 }
             }
         });

--- a/signup.html
+++ b/signup.html
@@ -45,6 +45,7 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="solutions.html">Solutions Exchange</a></li>
+                    <li class="nav-item"><a class="nav-link" href="service-metrics.html">Service Metrics</a></li>
                     <li class="nav-item"><a class="nav-link" href="guides.html">Guides</a></li>
                     <li class="nav-item"><a class="nav-link btn btn-primary text-white ms-2 px-3" href="signup.html">Sign Up</a></li>
                 </ul>
@@ -88,12 +89,11 @@
                                     <p>The GitHub GIG Cymru (GitHub Interest Group Wales) is a community of developers, healthcare professionals, and technology enthusiasts working together to improve healthcare through innovative digital solutions.</p>
                                     
                                     <h5>Who Can Join?</h5>
+                                    <div class="alert alert-warning mb-3">
+                                        <strong>Access Notice:</strong> Only users who are part of NHS Wales can have access to internal repositories and be members of GitHub GIG Cymru. Access is not available to external users.
+                                    </div>
                                     <ul>
-                                        <li><strong>NHS Wales Staff:</strong> Employees of NHS Wales organizations and health boards</li>
-                                        <li><strong>Healthcare Professionals:</strong> Clinicians, nurses, allied health professionals working in Wales</li>
-                                        <li><strong>Technology Teams:</strong> Developers, data scientists, and IT professionals in Welsh healthcare</li>
-                                        <li><strong>Academic Partners:</strong> Researchers and students from Welsh universities working on healthcare technology</li>
-                                        <li><strong>Public Sector:</strong> Local government and public health professionals in Wales</li>
+                                        <li><strong>NHS Wales Staff:</strong> Employees of NHS Wales organizations and health boards (only these users can access internal repositories and join GitHub GIG Cymru)</li>
                                     </ul>
 
                                     <h5>What You'll Get Access To</h5>
@@ -136,11 +136,11 @@
                                         <li>Enable two-factor authentication for security</li>
                                     </ol>
 
-                                    <h5>Step 2: Submit Your Application</h5>
-                                    <p>Complete the application process by providing:</p>
+                                    <h5>Step 2: Request Access</h5>
+                                    <p>To request access, raise a ticket with your local IT help desk. Your request will be escalated to the national IT service desk for triage and access setup. Please provide:</p>
                                     <ul>
                                         <li>Your GitHub username</li>
-                                        <li>NHS Wales or institutional email address</li>
+                                        <li>Your NHS Wales email address</li>
                                         <li>Your role and organization within NHS Wales</li>
                                         <li>Brief description of your interest in the community</li>
                                         <li>Any relevant technical skills or experience</li>

--- a/solutions.html
+++ b/solutions.html
@@ -67,6 +67,7 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link active" href="solutions.html">Solutions Exchange</a></li>
+                    <li class="nav-item"><a class="nav-link" href="service-metrics.html">Service Metrics</a></li>
                     <li class="nav-item"><a class="nav-link" href="guides.html">Guides</a></li>
                     <li class="nav-item"><a class="nav-link btn btn-primary text-white ms-2 px-3" href="signup.html">Sign Up</a></li>
                     <li class="nav-item dropdown ms-2">


### PR DESCRIPTION
- Updated sign up guidance in guides and signup pages: Only NHS Wales users can access internal repos and join GitHub GIG Cymru. Access is via local IT help desk ticket escalated to national IT.
- Added multiple new service metrics charts (language, stars, activity, etc.)
- Added Service Metrics link to navbar across all main site pages for easy access.